### PR TITLE
Update changelog disclaimer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ permalink: "/index.html"
 This site currently contains two online documentation books for Ruby:
 
 * [The Ruby Reference](https://rubyreferences.github.io/rubyref/): full language reference, compiled in a readable form from official sources.
-* [Ruby Changes](https://rubyreferences.github.io/rubychanges/): detailed language changelog (currently for 2.6 only, but it will be expanded to older and newer versions eventually)
+* [Ruby Changes](https://rubyreferences.github.io/rubychanges/): detailed language changelog (currently for 2.4+, but it will be expanded to older versions eventually).
 
 Source of this page is available at [GitHub repo](https://github.com/rubyreferences/rubyreferences.github.io), as well as the source for [all sub-sites](https://github.com/rubyreferences).


### PR DESCRIPTION
It seems there are versions from 2.4 to 2.7 now available, not just 2.6.